### PR TITLE
Bootstrap 4 support

### DIFF
--- a/inst/app/tools/analysis/clt_ui.R
+++ b/inst/app/tools/analysis/clt_ui.R
@@ -2,9 +2,9 @@
 # Central Limit Theorem
 ###############################
 clt_dist <- c(
-  "Normal" = "Normal", 
-  "Binomial" = "Binomial", 
-  "Uniform" = "Uniform", 
+  "Normal" = "Normal",
+  "Binomial" = "Binomial",
+  "Uniform" = "Uniform",
   "Exponential" = "Exponential"
 )
 clt_stat <- c("Sum" = "sum", "Mean" = "mean")
@@ -36,14 +36,14 @@ output$ui_clt <- renderUI({
         div(
           class = "row",
           div(
-            class = "col-xs-6",
+            class = "col-6 col-xs-6",
             numericInput(
               "clt_unif_min", "Min:",
               value = state_init("clt_unif_min", 0)
             )
           ),
           div(
-            class = "col-xs-6",
+            class = "col-6 col-xs-6",
             numericInput(
               "clt_unif_max", "Max:",
               value = state_init("clt_unif_max", 1)
@@ -56,14 +56,14 @@ output$ui_clt <- renderUI({
         div(
           class = "row",
           div(
-            class = "col-xs-6",
+            class = "col-6 col-xs-6",
             numericInput(
               "clt_norm_mean", "Mean:",
               value = state_init("clt_norm_mean", 0)
             )
           ),
           div(
-            class = "col-xs-6",
+            class = "col-6 col-xs-6",
             numericInput(
               "clt_norm_sd", "SD:",
               value = state_init("clt_norm_sd", 1),
@@ -85,7 +85,7 @@ output$ui_clt <- renderUI({
         div(
           class = "row",
           div(
-            class = "col-xs-6",
+            class = "col-6 col-xs-6",
             numericInput(
               "clt_binom_size", "Size:",
               value = state_init("clt_binom_size", 10),
@@ -93,7 +93,7 @@ output$ui_clt <- renderUI({
             )
           ),
           div(
-            class = "col-xs-6",
+            class = "col-6 col-xs-6",
             numericInput(
               "clt_binom_prob", "Prob:",
               value = state_init("clt_binom_prob", 0.2),
@@ -105,7 +105,7 @@ output$ui_clt <- renderUI({
       div(
         class = "row",
         div(
-          class = "col-xs-6",
+          class = "col-6 col-xs-6",
           numericInput(
             "clt_n", "Sample size:",
             value = state_init("clt_n", 100),
@@ -113,7 +113,7 @@ output$ui_clt <- renderUI({
           )
         ),
         div(
-          class = "col-xs-6",
+          class = "col-6 col-xs-6",
           numericInput(
             "clt_m", "# of samples:",
             value = state_init("clt_m", 100),
@@ -220,7 +220,7 @@ output$clt <- renderUI({
 observeEvent(input$clt_report, {
   outputs <- c("plot")
   inp_out <- list(list(stat = input$clt_stat, bins = input$clt_bins))
-  inp <- clt_inputs() 
+  inp <- clt_inputs()
   inp3 <- inp[!grepl("_", names(inp))]
   if (input$clt_dist == "Normal") {
     inp <- c(inp3, inp[grepl("norm_", names(inp))])
@@ -234,9 +234,9 @@ observeEvent(input$clt_report, {
 
   update_report(
     inp_main = clean_args(inp, clt_args),
-    fun_name = "clt", 
+    fun_name = "clt",
     inp_out = inp_out,
-    outputs = outputs, 
+    outputs = outputs,
     figs = TRUE,
     fig.width = clt_plot_width(),
     fig.height = clt_plot_height()
@@ -244,8 +244,8 @@ observeEvent(input$clt_report, {
 })
 
 download_handler(
-  id = "dlp_clt", 
-  fun = download_handler_plot, 
+  id = "dlp_clt",
+  fun = download_handler_plot,
   fn = function() paste0(tolower(input$clt_dist), "_clt"),
   type = "png",
   caption = "Save central limit theorem plot",

--- a/inst/app/tools/analysis/prob_calc_ui.R
+++ b/inst/app/tools/analysis/prob_calc_ui.R
@@ -1,6 +1,6 @@
 pc_dist <- c(
   "Binomial" = "binom", "Chi-squared" = "chisq", "Discrete" = "disc",
-  "Exponential" = "expo", "F" = "fdist", "Log normal" = "lnorm", 
+  "Exponential" = "expo", "F" = "fdist", "Log normal" = "lnorm",
   "Normal" = "norm", "Poisson" = "pois", "t" = "tdist", "Uniform" = "unif"
 )
 
@@ -12,11 +12,11 @@ make_pc_values_input <- function(lb, lb_init = NA, ub, ub_init = 0) {
   div(
     class = "row",
     div(
-      class = "col-xs-6",
+      class = "col-6 col-xs-6",
       numericInput(lb, "Lower bound:", value = state_init(lb, lb_init))
     ),
     div(
-      class = "col-xs-6",
+      class = "col-6 col-xs-6",
       numericInput(ub, "Upper bound:", value = state_init(ub, ub_init))
     )
   )
@@ -28,15 +28,15 @@ make_pc_prob_input <- function(lb, lb_init = NA, ub, ub_init = 0.95) {
   div(
     class = "row",
     div(
-      class = "col-xs-6",
+      class = "col-6 col-xs-6",
       numericInput(
         lb, "Lower bound:", value = state_init(lb, lb_init),
         min = 0, max = 1, step = .005
       )
     ),
     div(
-      class = "col-xs-6",
-      numericInput( 
+      class = "col-6 col-xs-6",
+      numericInput(
         ub, "Upper bound:", value = state_init(ub, ub_init),
         min = 0, max = 1, step = .005
       )
@@ -144,9 +144,9 @@ output$ui_pc_tdist <- renderUI({
       min = 3
     )
     # , div(class = "row",
-    #     div(class = "col-xs-6", numericInput("pct_mean", label = "Mean:",
+    #     div(class = "col-6 col-xs-6", numericInput("pct_mean", label = "Mean:",
     #                           value = state_init("pct_mean", 0))),
-    #     div(class = "col-xs-6",numericInput("pct_stdev", label = "St. dev:", min = 0,
+    #     div(class = "col-6 col-xs-6",numericInput("pct_stdev", label = "St. dev:", min = 0,
     #                          value = state_init("pct_stdev", 1)))
     # )
   )
@@ -165,14 +165,14 @@ output$ui_pc_norm <- renderUI({
     div(
       class = "row",
       div(
-        class = "col-xs-6",
+        class = "col-6 col-xs-6",
         numericInput(
           "pc_mean", "Mean:",
           value = state_init("pc_mean", 0)
         )
       ),
       div(
-        class = "col-xs-6",
+        class = "col-6 col-xs-6",
         numericInput(
           "pc_stdev", "St. dev:",
           min = 0,
@@ -196,14 +196,14 @@ output$ui_pc_lnorm <- renderUI({
     div(
       class = "row",
       div(
-        class = "col-xs-6",
+        class = "col-6 col-xs-6",
         numericInput(
           "pcln_meanlog", "Mean log:",
           value = state_init("pcln_meanlog", 0)
         )
       ),
       div(
-        class = "col-xs-6",
+        class = "col-6 col-xs-6",
         numericInput(
           "pcln_sdlog", "St. dev log:",
           min = 0,
@@ -227,14 +227,14 @@ output$ui_pc_binom <- renderUI({
     div(
       class = "row",
       div(
-        class = "col-xs-6",
+        class = "col-6 col-xs-6",
         numericInput(
           "pcb_n", label = "n:",
           value = state_init("pcb_n", 10), min = 0
         )
       ),
       div(
-        class = "col-xs-6",
+        class = "col-6 col-xs-6",
         numericInput(
           "pcb_p", "p:",
           min = 0, max = 1, step = .005,
@@ -258,14 +258,14 @@ output$ui_pc_unif <- renderUI({
     div(
       class = "row",
       div(
-        class = "col-xs-6",
+        class = "col-6 col-xs-6",
         numericInput(
           "pcu_min", "Min:",
           value = state_init("pcu_min", 0)
         )
       ),
       div(
-        class = "col-xs-6",
+        class = "col-6 col-xs-6",
         numericInput(
           "pcu_max", "Max:",
           value = state_init("pcu_max", 1)
@@ -593,8 +593,8 @@ observeEvent(input$prob_calc_report, {
 })
 
 download_handler(
-  id = "dlp_prob_calc", 
-  fun = download_handler_plot, 
+  id = "dlp_prob_calc",
+  fun = download_handler_plot,
   fn = function() paste0(input$pc_dist, "_prob_calc"),
   type = "png",
   caption = "Save probability calculator plot",


### PR DESCRIPTION
Bootstrap 3's `.col-xs-*` classes are equivalent to Bootstrap 4's `.col-*`. These changes make it so radiant can support both Bootstrap 3 and 4.

(See also https://github.com/radiant-rstats/radiant.data/pull/26)